### PR TITLE
Fixes error due to gca("projection")

### DIFF
--- a/src/GeometricTools_grid.jl
+++ b/src/GeometricTools_grid.jl
@@ -444,7 +444,13 @@ function plot(grid::Grid; fig_name="gridplot", fontsize=15,
   end
 
   fig = PyPlot.figure(fig_name)
-  ax = fig.gca(projection="3d")
+  ax = nothing  # To extend scope of ax outside try-catch block
+  try
+      ax = fig.gca(projection="3d")
+  catch err
+      # In case of error for newer Matplotlib versions
+      ax = fig.add_subplot(projection="3d")
+  end
   vectors_to_plot = []
 
   nc = grid.ncells


### PR DESCRIPTION
Newer versions do not support `gca("projection")` command. Instead `add_subplot("projection")` is used.
To support both versions of matplotlib, the command is enclosed in a try-catch block.

Ref.: [Stackoverflow thread](https://stackoverflow.com/questions/67095247/gca-and-latest-version-of-matplotlib)