### PR TITLE
Fix for isEdge()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1"

--- a/src/GeometricTools_gridspecials.jl
+++ b/src/GeometricTools_gridspecials.jl
@@ -459,16 +459,16 @@ function neighbor(grid::GridTriangleSurface, ni::Int, ci::Int;
 
     if preserveEdge
         isFakeNeighbor = false
-        inXmin = (isedge(grid, ci; whichedge=1) && ni==1)
-        inXmax = (isedge(grid, ci; whichedge=2) && ni==1)
-        inYmin = (isedge(grid, ci; whichedge=3) && ni==2)
-        inYmax = (isedge(grid, ci; whichedge=4) && ni==2)
+        inXmin = (isedge(grid, ci; whichedge=1) && ni==2)
+        inXmax = (isedge(grid, ci; whichedge=2) && ni==2)
+        inYmin = (isedge(grid, ci; whichedge=3) && ni==1)
+        inYmax = (isedge(grid, ci; whichedge=4) && ni==1)
 
         # This has only been tested for dim_split = 1
         if grid.orggrid.loop_dim == 2
-            isFakeNeighbor = inXmin || inXmax
-        elseif grid.orggrid.loop_dim == 1
             isFakeNeighbor = inYmin || inYmax
+        elseif grid.orggrid.loop_dim == 1
+            isFakeNeighbor = inXmin || inXmax
         else
             isFakeNeighbor = inXmin || inXmax || inYmin || inYmax
         end
@@ -514,15 +514,15 @@ function isedge(grid::GridTriangleSurface, ci::Int; whichedge::Int=0)
     # Determine if the cell is part of any boundary
     # Xmin, Xmax, Ymin, Ymax are the cell boundaries of the grid
     if grid.dimsplit == 2
-        inXmin = ci <= nx
-        inXmax = ci > 2*nx*ny - nx
-        inYmin = (ci-nx-1)%(2*nx) == 0
-        inYmax = (ci-nx)%(2*nx) == 0
+        inXmin = (ci-nx-1)%(2*nx) == 0
+        inXmax = (ci-nx)%(2*nx) == 0
+        inYmin = ci <= nx
+        inYmax = ci > 2*nx*ny - nx
     else
-        inXmin = ((ci+1)%2 == 0) && (ci < 2*nx)
-        inXmax = ((2*nx*ny-ci)%2 == 0) && (ci > 2*nx*(ny-1)+1)
-        inYmin = (ci-2)%(2*nx) == 0
-        inYmax = (ci-(2*nx-1))%(2*nx) == 0
+        inXmin = (ci-2)%(2*nx) == 0
+        inXmax = (ci-(2*nx-1))%(2*nx) == 0
+        inYmin = ((ci+1)%2 == 0) && (ci < 2*nx)
+        inYmax = ((2*nx*ny-ci)%2 == 0) && (ci > 2*nx*(ny-1)+1)
     end
 
     if whichedge == 1; ret = inXmin
@@ -531,10 +531,10 @@ function isedge(grid::GridTriangleSurface, ci::Int; whichedge::Int=0)
     elseif whichedge == 4; ret = inYmax
     else
         if grid.orggrid.loop_dim == 2
-            ret = inYmin || inYmax
+            ret = inXmin || inXmax
 
         elseif grid.orggrid.loop_dim == 1
-            ret = inXmin || inXmax
+            ret = inYmin || inYmax
 
         else  # For loop_dim = 0 and loop_dim > 2
             ret = inXmin || inXmax || inYmin || inYmax

--- a/src/GeometricTools_gridspecials.jl
+++ b/src/GeometricTools_gridspecials.jl
@@ -478,7 +478,7 @@ function neighbor(grid::GridTriangleSurface, ni::Int, ccoor::CartesianIndex)
     return neighbor(ni, ci, ccoor, ndivscells, grid.dimsplit)
 end
 
-function isedge(grid::GridTriangleSurface, ci)
+function isedge(grid::GridTriangleSurface, ci::Int)
 
     ret = false
     nx = grid.orggrid.NDIVS[1]

--- a/src/GeometricTools_gridspecials.jl
+++ b/src/GeometricTools_gridspecials.jl
@@ -466,9 +466,9 @@ function neighbor(grid::GridTriangleSurface, ni::Int, ci::Int;
 
         # This has only been tested for dim_split = 1
         if grid.orggrid.loop_dim == 2
-            isFakeNeighbor = inYmin || inYmax
-        elseif grid.orggrid.loop_dim == 1
             isFakeNeighbor = inXmin || inXmax
+        elseif grid.orggrid.loop_dim == 1
+            isFakeNeighbor = inYmin || inYmax
         else
             isFakeNeighbor = inXmin || inXmax || inYmin || inYmax
         end

--- a/src/GeometricTools_gridspecials.jl
+++ b/src/GeometricTools_gridspecials.jl
@@ -478,7 +478,11 @@ function neighbor(grid::GridTriangleSurface, ni::Int, ccoor::CartesianIndex)
     return neighbor(ni, ci, ccoor, ndivscells, grid.dimsplit)
 end
 
-function isedge(grid::GridTriangleSurface, ci::Int)
+function isedge(grid::GridTriangleSurface, ci::Int; whichedge::Int=0)
+    # whichedge takes values 1,2,3,4 or 0 (default)
+    # [1, 2, 3, 4] = [Xmin, Xmax, Ymin, Ymax]
+    # If whichedge is used, it checks only that specific boundary
+
 
     ret = false
     nx = grid.orggrid.NDIVS[1]
@@ -498,15 +502,21 @@ function isedge(grid::GridTriangleSurface, ci::Int)
         inYmax = (ci-(2*nx-1))%(2*nx) == 0
     end
 
-    if grid.orggrid.loop_dim == 2
-        ret = inYmin || inYmax
+    if whichedge == 1; ret = inXmin
+    elseif whichedge == 2; ret = inXmax
+    elseif whichedge == 3; ret = inYmin
+    elseif whichedge == 4; ret = inYmax
+    else
+        if grid.orggrid.loop_dim == 2
+            ret = inYmin || inYmax
 
-    elseif grid.orggrid.loop_dim == 1
-        ret = inXmin || inXmax
+        elseif grid.orggrid.loop_dim == 1
+            ret = inXmin || inXmax
 
-    else  # For loop_dim = 0 and loop_dim > 2
-        ret = inXmin || inXmax || inYmin || inYmax
+        else  # For loop_dim = 0 and loop_dim > 2
+            ret = inXmin || inXmax || inYmin || inYmax
 
+        end
     end
 
     return ret

--- a/src/GeometricTools_gridspecials.jl
+++ b/src/GeometricTools_gridspecials.jl
@@ -501,7 +501,7 @@ function isedge(grid::GridTriangleSurface, ci)
     if grid.orggrid.loop_dim == 2
         ret = inYmin || inYmax
 
-    elseif loop_dim == 1
+    elseif grid.orggrid.loop_dim == 1
         ret = inXmin || inXmax
 
     else  # For loop_dim = 0 and loop_dim > 2

--- a/src/GeometricTools_gridspecials.jl
+++ b/src/GeometricTools_gridspecials.jl
@@ -478,10 +478,13 @@ function neighbor(grid::GridTriangleSurface, ni::Int, ccoor::CartesianIndex)
     return neighbor(ni, ci, ccoor, ndivscells, grid.dimsplit)
 end
 
-function isedge(grid::GridTriangleSurface, coor)
+function isedge(grid::GridTriangleSurface, ci)
+
+    ret = false
+    nx = grid.orggrid.NDIVS[1]
+    ny = grid.orggrid.NDIVS[2]
 
     if grid.orggrid.loop_dim == 0
-        ret = false
         # Find original grid index
         ciMod2 = ci%2
         if ciMod2 == 0
@@ -517,19 +520,27 @@ function isedge(grid::GridTriangleSurface, coor)
             ret = false
         end
 
-    else  # This only works for loop_dim = 2
-        isnot = true
-        for i in 1:length(coor)
-            isnot *= i==grid.orggrid.loop_dim ||
-                    !(
-                        (coor[i]==(grid.dimsplit==i ? 2 : 1) && grid._ndivscells[i]>1) ||
-                        coor[i]==(grid._ndivscells[i] - (grid.dimsplit==i ? 1 : 0))
-                    )
+    else
+        # This was the previous logic for loop_dim = 2
+        # isnot = true
+        # for i in 1:length(ci)
+        #     isnot *= i==grid.orggrid.loop_dim ||
+        #             !(
+        #                 (ci[i]==(grid.dimsplit==i ? 2 : 1) && grid._ndivscells[i]>1) ||
+        #                 ci[i]==(grid._ndivscells[i] - (grid.dimsplit==i ? 1 : 0))
+        #             )
+        # end
+        # ret = !isnot
+
+        if (ci-2)%(2*nx) == 0
+            ret = true
+        elseif (ci-(2*nx-1))%(2*nx) == 0
+            ret = true
         end
-        ret = !isnot
+
     end
 
-    if grid.dimsplit!=1
+    if grid.dimsplit != 1 || grid.orggrid.loop_dim ==1
         @warn("Case dimsplit=$(grid.dimsplit) has not been verified yet. Expect it to be wrong.")
     end
 

--- a/src/GeometricTools_gridspecials.jl
+++ b/src/GeometricTools_gridspecials.jl
@@ -445,7 +445,7 @@ function neighbor(ni::Int, ci::Int, ccoor, ndivscells, dimsplit::Int)
 end
 
 function neighbor(grid::GridTriangleSurface, ni::Int, ci::Int;
-    preserveEdge::Bool=false)
+                    preserveEdge::Bool=false)
     # Preserve edge will output [0,0,0] for a non-existent neighbor cell
     # This happens for cells at the edges of the grid
 
@@ -479,7 +479,8 @@ function neighbor(grid::GridTriangleSurface, ni::Int, ci::Int;
 end
 
 function neighbor(grid::GridTriangleSurface, ni::Int,
-                    ccoor::Union{<:AbstractVector, <:Tuple})
+                    ccoor::Union{<:AbstractVector, <:Tuple};
+                    preserveEdge::Bool=false)
 
     # Pre-calculations
     ndivscells = Tuple(collect( 1:(d != 0 ? d : 1) for d in grid._ndivscells))
@@ -487,10 +488,11 @@ function neighbor(grid::GridTriangleSurface, ni::Int,
     ci = lin[ccoor...]
 
     # Calculate neighbor
-    return neighbor(ni, ci, ccoor, ndivscells, grid.dimsplit)
+    return neighbor(grid, ni, ci; preserveEdge=preserveEdge)
 end
 
-function neighbor(grid::GridTriangleSurface, ni::Int, ccoor::CartesianIndex)
+function neighbor(grid::GridTriangleSurface, ni::Int, ccoor::CartesianIndex;
+                    preserveEdge::Bool=false)
 
     # Pre-calculations
     ndivscells = Tuple(collect( 1:(d != 0 ? d : 1) for d in grid._ndivscells))
@@ -498,7 +500,7 @@ function neighbor(grid::GridTriangleSurface, ni::Int, ccoor::CartesianIndex)
     ci = lin[ccoor]
 
     # Calculate neighbor
-    return neighbor(ni, ci, ccoor, ndivscells, grid.dimsplit)
+    return neighbor(grid, ni, ci; preserveEdge=preserveEdge)
 end
 
 function isedge(grid::GridTriangleSurface, ci::Int; whichedge::Int=0)

--- a/src/GeometricTools_gridspecials.jl
+++ b/src/GeometricTools_gridspecials.jl
@@ -484,7 +484,35 @@ function isedge(grid::GridTriangleSurface, ci)
     nx = grid.orggrid.NDIVS[1]
     ny = grid.orggrid.NDIVS[2]
 
-    if grid.orggrid.loop_dim == 0
+    if grid.orggrid.loop_dim == 2
+
+        # This was the previous logic for loop_dim = 2
+        # isnot = true
+        # for i in 1:length(ci)
+        #     isnot *= i==grid.orggrid.loop_dim ||
+        #             !(
+        #                 (ci[i]==(grid.dimsplit==i ? 2 : 1) && grid._ndivscells[i]>1) ||
+        #                 ci[i]==(grid._ndivscells[i] - (grid.dimsplit==i ? 1 : 0))
+        #             )
+        # end
+        # ret = !isnot
+
+        if (ci-2)%(2*nx) == 0
+            ret = true
+        elseif (ci-(2*nx-1))%(2*nx) == 0
+            ret = true
+        end
+
+    elseif grid.orggrid.loop_dim == 1
+
+        if (ci%2 == 1) && (ci < 2*nx)
+            ret = true
+        elseif ((2*nx*ny-ci)%2 == 0) && (ci > 2*nx*(ny-1)+1)
+            ret = true
+        end
+
+    else  # For loop_dim = 0 and loop_dim > 2
+
         # Find original grid index
         ciMod2 = ci%2
         if ciMod2 == 0
@@ -519,28 +547,9 @@ function isedge(grid::GridTriangleSurface, ci)
         if ci == nx*2 || ci == 2*(nx*(ny-1))+1
             ret = false
         end
-
-    else
-        # This was the previous logic for loop_dim = 2
-        # isnot = true
-        # for i in 1:length(ci)
-        #     isnot *= i==grid.orggrid.loop_dim ||
-        #             !(
-        #                 (ci[i]==(grid.dimsplit==i ? 2 : 1) && grid._ndivscells[i]>1) ||
-        #                 ci[i]==(grid._ndivscells[i] - (grid.dimsplit==i ? 1 : 0))
-        #             )
-        # end
-        # ret = !isnot
-
-        if (ci-2)%(2*nx) == 0
-            ret = true
-        elseif (ci-(2*nx-1))%(2*nx) == 0
-            ret = true
-        end
-
     end
 
-    if grid.dimsplit != 1 || grid.orggrid.loop_dim ==1
+    if grid.dimsplit != 1
         @warn("Case dimsplit=$(grid.dimsplit) has not been verified yet. Expect it to be wrong.")
     end
 

--- a/src/GeometricTools_gridspecials.jl
+++ b/src/GeometricTools_gridspecials.jl
@@ -480,7 +480,7 @@ end
 
 function isedge(grid::GridTriangleSurface, coor)
 
-    if loop_dim == 0
+    if grid.orggrid.loop_dim == 0
         ret = false
         # Find original grid index
         ciMod2 = ci%2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,3 @@
+verbose = true
+
+include("runtests_gridspecials.jl")

--- a/test/runtests_gridspecials.jl
+++ b/test/runtests_gridspecials.jl
@@ -7,7 +7,7 @@ catch
     global verbose = true
 end
 
-@testset verbose=verbose "isedge Tests" begin
+@testset verbose=verbose "Gridspecials Tests" begin
 
     # --- isedge() ---
     if verbose
@@ -57,6 +57,224 @@ end
 
             @test all(edgeCellsEval[loop_dim+1, dim_split, :] == 
                       edgeCells[loop_dim+1, dim_split, :])
+        end
+
+        if verbose; println(""); end
+    end
+
+    # --- isedge() ---
+    if verbose
+        println("Testing neighbor()...")
+        println("Generating 4 x 3 unit grid...")
+    end
+
+    Pmin = [0.0, 0.0, 0.0]
+    Pmax = [1.0, 1.0, 0.0]
+    n = [4, 3, 0]
+
+    loop_dims = [0, 1, 2]
+    dim_splits = [1]
+
+    # Case: inner cell
+    ci = 11
+    # Correct values for neigbor
+    neighCells = Array{Int, 3}(undef, length(loop_dims), length(dim_splits), 3)
+    neighCellsEval = Array{Int, 3}(undef, length(loop_dims), length(dim_splits), 3)
+
+    neighCellsEval .= 0
+    # dim_split = 1
+    neighCells[1, 1, :] = [4, 14, 12]
+    neighCells[2, 1, :] = [4, 14, 12]
+    neighCells[3, 1, :] = [4, 14, 12]
+
+    for dim_split in dim_splits
+        if verbose; print("Testing dim_split=$dim_split loop_dim="); end
+
+        for loop_dim in loop_dims
+            if verbose; print("$loop_dim, "); end
+
+            grid = gt.Grid(Pmin, Pmax, n, loop_dim)
+            trigrid = gt.GridTriangleSurface(grid, dim_split)
+            ndivs = Tuple(collect(1:(d !=0 ? d : 1) for d in trigrid._ndivscells))
+            linc = LinearIndices(ndivs)
+
+            for ni = 1:3
+                cidx = gt.neighbor(trigrid, ni, ci; preserveEdge=true)
+                neighCellsEval[loop_dim+1, dim_split, ni] = linc[cidx...]
+            end
+
+            @test all(neighCellsEval[loop_dim+1, dim_split, :] == 
+                      neighCells[loop_dim+1, dim_split, :])
+        end
+
+        if verbose; println(""); end
+    end
+
+    # Case: cell on Xmin edge
+    ci = 10
+
+    # dim_split = 1
+    neighCells[1, 1, :] = [17, 0, 9]
+    neighCells[2, 1, :] = [17, 15, 9]
+    neighCells[3, 1, :] = [17, 0, 9]
+
+    neighCellsEval .= 0
+    for dim_split in dim_splits
+        if verbose; print("Testing dim_split=$dim_split loop_dim="); end
+
+        for loop_dim in loop_dims
+            if verbose; print("$loop_dim, "); end
+
+            grid = gt.Grid(Pmin, Pmax, n, loop_dim)
+            trigrid = gt.GridTriangleSurface(grid, dim_split)
+            ndivs = Tuple(collect(1:(d !=0 ? d : 1) for d in trigrid._ndivscells))
+            linc = LinearIndices(ndivs)
+
+            for ni = 1:3
+                cidx = gt.neighbor(trigrid, ni, ci; preserveEdge=true)
+                if !all(cidx == [0,0,0])
+                    neighCellsEval[loop_dim+1, dim_split, ni] = linc[cidx...]
+                end
+            end
+
+            @test all(neighCellsEval[loop_dim+1, dim_split, :] == 
+                      neighCells[loop_dim+1, dim_split, :])
+        end
+
+        if verbose; println(""); end
+    end
+
+    # Case: cell on Xmax edge
+    ci = 23
+
+    # dim_split = 1
+    neighCells[1, 1, :] = [16, 0, 24]
+    neighCells[2, 1, :] = [16, 18, 24]
+    neighCells[3, 1, :] = [16, 0, 24]
+
+    neighCellsEval .= 0
+    for dim_split in dim_splits
+        if verbose; print("Testing dim_split=$dim_split loop_dim="); end
+
+        for loop_dim in loop_dims
+            if verbose; print("$loop_dim, "); end
+
+            grid = gt.Grid(Pmin, Pmax, n, loop_dim)
+            trigrid = gt.GridTriangleSurface(grid, dim_split)
+            ndivs = Tuple(collect(1:(d !=0 ? d : 1) for d in trigrid._ndivscells))
+            linc = LinearIndices(ndivs)
+
+            for ni = 1:3
+                cidx = gt.neighbor(trigrid, ni, ci; preserveEdge=true)
+                if !all(cidx == [0,0,0])
+                    neighCellsEval[loop_dim+1, dim_split, ni] = linc[cidx...]
+                end
+            end
+
+            @test all(neighCellsEval[loop_dim+1, dim_split, :] == 
+                      neighCells[loop_dim+1, dim_split, :])
+        end
+
+        if verbose; println(""); end
+    end
+
+    # Case: cell on Ymin edge
+    ci = 3
+
+    # dim_split = 1
+    neighCells[1, 1, :] = [0, 6, 4]
+    neighCells[2, 1, :] = [0, 6, 4]
+    neighCells[3, 1, :] = [20, 6, 4]
+
+    neighCellsEval .= 0
+    for dim_split in dim_splits
+        if verbose; print("Testing dim_split=$dim_split loop_dim="); end
+
+        for loop_dim in loop_dims
+            if verbose; print("$loop_dim, "); end
+
+            grid = gt.Grid(Pmin, Pmax, n, loop_dim)
+            trigrid = gt.GridTriangleSurface(grid, dim_split)
+            ndivs = Tuple(collect(1:(d !=0 ? d : 1) for d in trigrid._ndivscells))
+            linc = LinearIndices(ndivs)
+
+            for ni = 1:3
+                cidx = gt.neighbor(trigrid, ni, ci; preserveEdge=true)
+                if !all(cidx == [0,0,0])
+                    neighCellsEval[loop_dim+1, dim_split, ni] = linc[cidx...]
+                end
+            end
+
+            @test all(neighCellsEval[loop_dim+1, dim_split, :] == 
+                      neighCells[loop_dim+1, dim_split, :])
+        end
+
+        if verbose; println(""); end
+    end
+
+    # Case: cell on Ymax edge
+    ci = 24
+
+    # dim_split = 1
+    neighCells[1, 1, :] = [0, 21, 23]
+    neighCells[2, 1, :] = [0, 21, 23]
+    neighCells[3, 1, :] = [7, 21, 23]
+
+    neighCellsEval .= 0
+    for dim_split in dim_splits
+        if verbose; print("Testing dim_split=$dim_split loop_dim="); end
+
+        for loop_dim in loop_dims
+            if verbose; print("$loop_dim, "); end
+
+            grid = gt.Grid(Pmin, Pmax, n, loop_dim)
+            trigrid = gt.GridTriangleSurface(grid, dim_split)
+            ndivs = Tuple(collect(1:(d !=0 ? d : 1) for d in trigrid._ndivscells))
+            linc = LinearIndices(ndivs)
+
+            for ni = 1:3
+                cidx = gt.neighbor(trigrid, ni, ci; preserveEdge=true)
+                if !all(cidx == [0,0,0])
+                    neighCellsEval[loop_dim+1, dim_split, ni] = linc[cidx...]
+                end
+            end
+
+            @test all(neighCellsEval[loop_dim+1, dim_split, :] == 
+                      neighCells[loop_dim+1, dim_split, :])
+        end
+
+        if verbose; println(""); end
+    end
+
+    # Case: cell on Xmin, Ymax edge
+    ci = 18
+
+    # dim_split = 1
+    neighCells[1, 1, :] = [0, 0, 17]
+    neighCells[2, 1, :] = [0, 23, 17]
+    neighCells[3, 1, :] = [1, 0, 17]
+
+    neighCellsEval .= 0
+    for dim_split in dim_splits
+        if verbose; print("Testing dim_split=$dim_split loop_dim="); end
+
+        for loop_dim in loop_dims
+            if verbose; print("$loop_dim, "); end
+
+            grid = gt.Grid(Pmin, Pmax, n, loop_dim)
+            trigrid = gt.GridTriangleSurface(grid, dim_split)
+            ndivs = Tuple(collect(1:(d !=0 ? d : 1) for d in trigrid._ndivscells))
+            linc = LinearIndices(ndivs)
+
+            for ni = 1:3
+                cidx = gt.neighbor(trigrid, ni, ci; preserveEdge=true)
+                if !all(cidx == [0,0,0])
+                    neighCellsEval[loop_dim+1, dim_split, ni] = linc[cidx...]
+                end
+            end
+
+            @test all(neighCellsEval[loop_dim+1, dim_split, :] == 
+                      neighCells[loop_dim+1, dim_split, :])
         end
 
         if verbose; println(""); end

--- a/test/runtests_gridspecials.jl
+++ b/test/runtests_gridspecials.jl
@@ -1,0 +1,64 @@
+using Test
+import GeometricTools as gt
+
+try
+    verbose
+catch
+    global verbose = true
+end
+
+@testset verbose=verbose "isedge Tests" begin
+
+    # --- isedge() ---
+    if verbose
+        println("Testing isedge()...")
+        println("Generating 4 x 3 unit grid...")
+    end
+
+    Pmin = [0.0, 0.0, 0.0]
+    Pmax = [1.0, 1.0, 0.0]
+    n = [4, 3, 0]
+
+    loop_dims = [0, 1, 2]
+    dim_splits = [1, 2]
+
+    # Truth table for isEdge
+    edgeCells = Array{Int, 3}(undef, 
+                              length(loop_dims), 
+                              length(dim_splits), 
+                              2*n[1]*n[2])
+    edgeCellsEval = Array{Int, 3}(undef,
+                                  length(loop_dims), 
+                                  length(dim_splits), 
+                                  2*n[1]*n[2])
+
+    # Case dim_split = 1
+    edgeCells[1,1,:] = [1,1,1,0,1,0,1,0,0,1,0,0,0,0,1,0,0,1,0,1,0,1,1,1]
+    edgeCells[2,1,:] = [1,0,1,0,1,0,1,0,0,0,0,0,0,0,0,0,0,1,0,1,0,1,0,1]
+    edgeCells[3,1,:] = [0,1,0,0,0,0,1,0,0,1,0,0,0,0,1,0,0,1,0,0,0,0,1,0]
+
+    # Case dim_split = 2
+    edgeCells[1,2,:] = [1,1,1,1,1,0,0,0,0,0,0,1,1,0,0,0,0,0,0,1,1,1,1,1]
+    edgeCells[2,2,:] = [1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1]
+    edgeCells[3,2,:] = [0,0,0,1,1,0,0,0,0,0,0,1,1,0,0,0,0,0,0,1,1,0,0,0]
+
+    for dim_split in dim_splits
+        if verbose; print("Testing dim_split=$dim_split loop_dim="); end
+
+        for loop_dim in loop_dims
+            if verbose; print("$loop_dim, "); end
+
+            grid = gt.Grid(Pmin, Pmax, n, loop_dim)
+            trigrid = gt.GridTriangleSurface(grid, dim_split)
+
+            for ci = 1:trigrid.ncells
+                edgeCellsEval[loop_dim+1, dim_split, ci] = gt.isedge(trigrid, ci)
+            end
+
+            @test all(edgeCellsEval[loop_dim+1, dim_split, :] == 
+                      edgeCells[loop_dim+1, dim_split, :])
+        end
+
+        if verbose; println(""); end
+    end
+end


### PR DESCRIPTION
The `isEdge()` function wasn't working or hadn't been implemented in the following cases:
1. `loop_dim = 0`
2. `loop_dim = 1`
3. `loop_dim = 2` (Implemented, but hard to understand logic)
4. All cases above with `dim_split = 2`

The general logic has been re-written to make it easier to understand and reuse for all cases.
All cases were tested with the following test code and a sample sphere geometry.
```julia
using Revise
import GeometricTools as gt

function isedge(ci, nx, ny, loop_dim, dim_split)
    ret = false

    # Determine if the cell is part of any boundary
    # Xmin, Xmax, Ymin, Ymax are the cell boundaries of the grid
    if dim_split == 1
        inXmin = ((ci+1)%2 == 0) && (ci < 2*nx)
        inXmax = ((2*nx*ny-ci)%2 == 0) && (ci > 2*nx*(ny-1)+1)
        inYmin = (ci-2)%(2*nx) == 0
        inYmax = (ci-(2*nx-1))%(2*nx) == 0
    else
        inXmin = ci <= nx
        inXmax = ci > 2*nx*ny - nx
        inYmin = (ci-nx-1)%(2*nx) == 0
        inYmax = (ci-nx)%(2*nx) == 0
    end

    if loop_dim == 2
        ret = inYmin || inYmax
    elseif loop_dim == 1
        ret = inXmin || inXmax
    else  # For loop_dim = 0 and loop_dim > 2
        ret = inXmin || inXmax || inYmin || inYmax
    end

    return ret
end

Pmin = [0.0, 0.0, 0.0]
Pmax = [1.0, 1.0, 0.0]

nx = 4
ny = 3
n = [nx, ny, 0]  # n x n grid

loop_dim = 2
@show loop_dim
grid = gt.Grid(Pmin, Pmax, n, loop_dim)

dim_split = 2
@show dim_split
trigrid = gt.GridTriangleSurface(grid, dim_split)

# Save numbering
linc = collect(1:trigrid.ncells)
gt.add_field(trigrid, "li", "scalar", linc, "cell")

ndivs = Tuple(collect(1:(d !=0 ? d : 1) for d in trigrid._ndivscells))

edgeCell = Vector{Int}(undef, 2*nx*ny)

for ci = 1:(nx*ny*2)

    # Print out inner cells
    # if !gt.isedge(trigrid, ci)
    if isedge(ci, n[1], n[2], loop_dim, dim_split)
        edgeCell[ci] = 1
    end
end

gt.add_field(trigrid, "edgeCell", "scalar", edgeCell, "cell")
gt.save_vtk(trigrid, "gridCheck")
```